### PR TITLE
Removed ambiguities and invalid indentifiers in the latest version of…

### DIFF
--- a/AstBlaise.lhs
+++ b/AstBlaise.lhs
@@ -23,6 +23,7 @@ Suite 330, Boston, MA 02111-1307 USA
 
 \begin{code}
 module AstBlaise where
+import Prelude hiding ((<$>))
 import PPrint
 \end{code}
 

--- a/AstBloop.hs
+++ b/AstBloop.hs
@@ -20,6 +20,7 @@ module AstBloop
   , prettyShow
   )
 where
+import Prelude hiding ((<$>))
 import PPrint
 import Data.Generics
 

--- a/AstC.lhs
+++ b/AstC.lhs
@@ -10,7 +10,7 @@
 \maketitle
 
 Originally snarfed from the FrontC code, then translated from ML using
-Emacs macros. Originally Copyright Hugues Cassé, released under
+Emacs macros. Originally Copyright Hugues Cassï¿½, released under
 GPL. I've thrown out all K$\&$R specific stuff, but kept the ANSI and GNU
 stuff. I've redone all of the declaration stuff. 
 
@@ -36,9 +36,10 @@ Suite 330, Boston, MA 02111-1307 USA
 
 \begin{code}
 module AstC where
+import Prelude hiding ((<$>))
 import PPrint
 import Data.Maybe ( fromMaybe )
-import Data.Generics
+import Data.Generics hiding (empty)
 \end{code}
 
 The symbols \verb.<>., \verb.<$>. and \verb.<+>. in PPrint are written

--- a/Main.lhs
+++ b/Main.lhs
@@ -27,7 +27,7 @@ module Main where
 import System.Console.GetOpt
 import Data.Maybe ( fromMaybe )
 import System.IO
-import System.IO.Error ( try )
+import System.IO.Error ( tryIOError )
 import System.Environment ( getArgs )
 import System.Posix ( unionFileModes, ownerExecuteMode,
                       setFileMode, fileMode, getFileStatus )
@@ -143,7 +143,7 @@ compileTo target (_:xs) = compileTo target xs
 Read library files from an obvious location:
 \begin{code}
 getInstalledFile :: String -> String -> IO String
-getInstalledFile path fn = do s <- try (readFile fn)
+getInstalledFile path fn = do s <- tryIOError (readFile fn)
                               case s of
                                Left _ -> readFile (path ++ fn)
                                Right a -> return a

--- a/PPrint.hs
+++ b/PPrint.hs
@@ -72,7 +72,8 @@ module PPrint
         , displayS, displayIO                
         ) where
 
-import IO      (Handle,hPutStr,hPutChar,stdout)
+import Prelude hiding ((<$>))
+import System.IO      (Handle,hPutStr,hPutChar,stdout)
 
 infixr 5 </>,<//>,<$>,<$$>
 infixr 6 <>,<+>


### PR DESCRIPTION
… GHC.

Explict import of Prelude with '(<$>)' hidden as it is ambigious with the PPrint module identifier. (AstBlaise.lsh, AstBloop.hs, AstC.lhs PPrint.hs)
Explict import of Prelude with 'empty' hidden as it is ambigious with the PPrint module identifier. (AstC.lhs)
Import of System.IO.Error brings into scope tryIOError instead of try.